### PR TITLE
added livesplit cycle fix

### DIFF
--- a/DS2.asl
+++ b/DS2.asl
@@ -54,6 +54,12 @@ startup
         }	    
 }
 
+onStart
+{
+    // This is a "cycle fix" that makes sure the timer always starts at 0.00 when starting during a load
+    timer.IsGameTimePaused = true;
+}
+
 init 
 {
     switch (modules.First().ModuleMemorySize) { // This is to know what version you are playing on


### PR DESCRIPTION
ensures the timer always starts at 0.00 on a load screen, without this fix it takes livesplit sometimes up to 0.06 seconds to realize the timer should be paused during a loading state